### PR TITLE
TABUS -- Facilitating MITUS & Tabby2 interfacing

### DIFF
--- a/R/model_load.R
+++ b/R/model_load.R
@@ -69,6 +69,7 @@ model_load<-function(loc="US", return_env=F){
 		for (object_name in ls(output_env)) {
 			assign(x = object_name, value = get(object_name, envir = output_env), envir = .GlobalEnv)
 		}
+		return(invisible(NULL))
 	}
 }
 


### PR DESCRIPTION
OK, sorry there's 3 commits instead of 1. 

The first one adds the return_env argument to the model_load function. 

The second one adds the model_load_demo that I accidentally deleted. 

The third one adds the return(invisible(NULL)) that I accidentally dropped when return_env is false. 

Thanks! 